### PR TITLE
Added support for VS Code dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+	"name": "larry: Go",
+	"dockerComposeFile": ["../docker-compose.yml", "docker-compose.yml"],
+	"service": "larry",
+	"workspaceFolder": "/go/src/larry",
+	"runServices": ["larry"],
+
+	"settings": {
+		"go.toolsManagement.checkForUpdates": "local",
+		"go.useLanguageServer": true,
+		"go.gopath": "/go",
+		"go.goroot": "/usr/local/go"
+	},
+
+	"extensions": [
+		"golang.Go",
+		"eamodio.gitlens"
+	]
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.5'
+
+services:
+  larry:
+    build:
+      target: dev
+    image: larry:dev
+    volumes:
+      - ./:/go/src/larry
+    entrypoint: sh -c "while sleep 1000; do :; done"
+    

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Launch",
+			"type": "go",
+			"request": "launch",
+			"mode": "auto",
+			"trace" : "verbose", 
+			"program": "${workspaceFolder}/cmd/larry/",
+			"cwd": "${workspaceFolder}/",
+			"args": ["-t", "golang", "-x", "1", "--safe-mode"]
+		}
+	]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,15 @@
-FROM golang:alpine AS compiler
-
-# Build directory.
+FROM alpine:3.12 AS base
 WORKDIR /go/src/larry
+RUN apk update && apk upgrade && apk add tzdata
+
+FROM golang:alpine AS dev
+ENV CGO_ENABLED=0
+RUN --mount=type=cache,target=/go/pkg mkdir -p go/bin && cd /go/bin && \
+	go install github.com/go-delve/delve/cmd/dlv@latest && \
+	go install golang.org/x/tools/gopls@latest &&\
+    apk add --no-cache bash git make
+
+FROM dev AS compiler
 
 # Add go modules and env files to the WORKDIR and install dependencies.
 ADD go.mod go.sum ./
@@ -12,9 +20,7 @@ ADD . ./
 RUN go build -o /bin/larry -ldflags="-w -s" cmd/larry/main.go
 
 # Create final application image.
-FROM alpine:3.12
-
-RUN apk update && apk upgrade && apk add tzdata
+FROM base AS final
 
 COPY --from=compiler /bin/larry /larry
 


### PR DESCRIPTION
Added support to allow coding/debugging using VS Code within a docker dev container. 

- The new .devcontainer folder has the files required to build/run the docker development image for the Larry project
- The .vscode folder has the launch config for running and debugging the golang code within VS Code
- The Dockerfile now has a stage for development. This stage installs the gopls golang language server, the Delve golang debugger, and bash/git/make